### PR TITLE
fix missing semicolon in docs. 

### DIFF
--- a/lib/Try/Tiny.pm
+++ b/lib/Try/Tiny.pm
@@ -493,7 +493,7 @@ Instead, you should capture the return value:
     my $success = try {
       die;
       1;
-    }
+    };
     return unless $success;
 
     say "This text WILL NEVER appear!";


### PR DESCRIPTION
This looked wrong without a semicolon, so I tested it. Sure enough, it was a syntax error without it, and ran as expected with it.
