### PR TITLE
Avoid dependency on Test::More 0.88

### DIFF
--- a/t/global_destruction_forked.t
+++ b/t/global_destruction_forked.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More;
+use Test::More tests => 3;
 use Try::Tiny;
 
 {
@@ -54,4 +54,4 @@ try {
 }
 finally { exit 1 if $parent != $$ };
 
-done_testing;
+pass("Didn't just exit");


### PR DESCRIPTION
The use of done_testing implies a dependency of Test::More 0.88 or
later. To avoid this, and provide compatibility with older versions,
remove done_testing and supply a test plan.

To ensure that the end of the test is reached (rather than exiting
early due to an error), I added an additional "pass" test to bump
the test count.
