### PR TITLE
Better docs on capturing success with catch block

### DIFF
--- a/lib/Try/Tiny.pm
+++ b/lib/Try/Tiny.pm
@@ -500,9 +500,7 @@ Instead, you should capture the return value:
 
     say "This text WILL NEVER appear!";
   }
-  
-  # or
-  
+  # OR
   sub parent_sub_with_catch {
     my $success = try {
       die;
@@ -512,6 +510,9 @@ Instead, you should capture the return value:
       # do something with $_
       return undef; #see note
     };
+    return unless $success;
+
+    say "This text WILL NEVER appear!";
   }
 
 Note that if you have a C<catch> block, it must return C<undef> for this to work,


### PR DESCRIPTION
While there is a note that calls it out below, I believe the behavior and usage of capturing success when also using a catch{} block is sufficiently different to the example that it merits its own example in the same code block. My rationale is twofold:

1) Because it is sufficiently different in behavior, giving an example goes a long way towards understanding.
2) Because this is a critical feature to have fail and it might be easy for someone reading the docs to digest the example and move on before reading the note below (which is unemphasized), it is best to have the second code example alongside the first with a meaningful name so that they are both digested at the same time.
