### PR TITLE
Add warning to POD about try/finally

### DIFF
--- a/lib/Try/Tiny.pm
+++ b/lib/Try/Tiny.pm
@@ -232,6 +232,13 @@ C<finally> blocks are always executed making them suitable for cleanup code
 which cannot be handled using local.  You can add as many C<finally> blocks to a
 given C<try> block as you like.
 
+Note that adding a C<finally> block without a preceding C<catch> block
+suppresses any errors. This behaviour is consistent with using a standalone
+C<eval>, but it is not consistent with C<try>/C<finally> patterns found in
+other programming languages, such as Java, Python, Javascript or C#. If you
+learnt the C<try>/C<finally> pattern from one of these languages, watch out for
+this.
+
 =head1 EXPORTS
 
 All functions are exported by default using L<Exporter>.


### PR DESCRIPTION
try/finally suppresses errors, which is unexpected behaviour if you come
from another programming language.
