### PR TITLE
add Sub::Name, perl 5.010 to test recommendations

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Try-Tiny
 
 {{$NEXT}}
+  - optional dependencies used in tests are added as recommended prereqs
+    (Karen Etheridge, PR#18)
 
 0.21  2014-04-15
   - also skip the test if Capture::Tiny is too old (Martin Popel, #17)

--- a/dist.ini
+++ b/dist.ini
@@ -14,15 +14,14 @@ Git::Tag_tag_format = %N-%v
 Git::NextVersion_version_regexp = ^Try-Tiny-(.+)$
 
 [AutoPrereqs]
+
+[Prereqs::Soften]
 ; tests optionally require 5.010
-skip = ^perl$
+module = perl
 ; tests for optional Sub::Name stuff
-skip = ^Sub::Name$
+module = Sub::Name
 ; tests optionally require Capture::Tiny
-skip = ^Capture::Tiny$
+module = Capture::Tiny
 
 [Prereqs]
 perl = 5.006
-
-[Prereqs / TestRecommends]
-Capture::Tiny = 0.12 ; capture_stderr

--- a/lib/Try/Tiny.pm
+++ b/lib/Try/Tiny.pm
@@ -3,14 +3,13 @@ use warnings;
 package Try::Tiny;
 # ABSTRACT: minimal try/catch with proper preservation of $@
 
-use 5.006;
 use Exporter 5.57 'import';
 our @EXPORT = our @EXPORT_OK = qw(try catch finally);
 
 use Carp;
 $Carp::Internal{+__PACKAGE__}++;
 
-BEGIN { eval "use Sub::Name; 1" or *{subname} = sub {1} }
+BEGIN { eval { require Sub::Name; Sub::Name->import; 1 } or *{subname} = sub {1} }
 
 # Need to prototype as @ not $$ because of the way Perl evaluates the prototype.
 # Keeping it at $$ means you only ever get 1 sub because we need to eval in a list


### PR DESCRIPTION
no other metadata or prereqs have changed (verified with 'dzil build --not' and a recursive diff against the last uploaded release)
