### PR TITLE
prefer Sub::Util to Sub::Name

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -26,5 +26,4 @@ perl = 5.006
 
 [Prereqs / TestRecommends]
 Capture::Tiny = 0.12 ; capture_stderr
-perl = 5.010
 Sub::Name = 0

--- a/dist.ini
+++ b/dist.ini
@@ -18,6 +18,7 @@ Git::NextVersion_version_regexp = ^Try-Tiny-(.+)$
 skip = ^perl$
 ; tests for optional Sub::Name stuff
 skip = ^Sub::Name$
+skip = ^Sub::Util$
 ; tests optionally require Capture::Tiny
 skip = ^Capture::Tiny$
 
@@ -26,4 +27,4 @@ perl = 5.006
 
 [Prereqs / TestRecommends]
 Capture::Tiny = 0.12 ; capture_stderr
-Sub::Name = 0
+Sub::Util = 0

--- a/t/named.t
+++ b/t/named.t
@@ -6,8 +6,9 @@ use warnings;
 use Test::More;
 
 BEGIN {
-    plan skip_all => "Sub::Name required"
-        unless eval { require Sub::Name; 1 };
+    plan skip_all => "Sub::Util or Sub::Name required"
+        unless eval { require Sub::Util; defined &Sub::Util::set_subname; }
+            || eval { require Sub::Name; Sub::Name->VERSION(0.08) };
     plan tests => 3;
 }
 


### PR DESCRIPTION
Sub::Util can name subs as well, and is in core in newer versions.  Try
to use it instead of Sub::Name, although prefer Sub::Name if it is
already loaded.

Each module has some edge cases though.  Sub::Name has a memory leak
prior to 0.08.  Some systems can end up with a version of Sub::Util that
doesn't have the set_subname sub.  Check for these cases as well when
picking a module to use.

Also optimize out the sub naming if neither module is available.

This addresses [RT#109139](https://rt.cpan.org/Ticket/Display.html?id=109139) and elastic/elasticsearch-perl#45
